### PR TITLE
corrected the options of MyMemory provider

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -30,7 +30,7 @@ Is a free provider but very  complete
 
 ``MyMemory`` (located at ``translate.providers``) receives the following options:
 
-to_lang, from_lang='en', secret_access_key
+to_lang, from_lang='en', email
 
     * ``to_lang``: language you want to translate
     * ``from_lang``: Language of the text being translated  (optional): as default ``autodetect``


### PR DESCRIPTION
The option `secret_access_key` does not exist for MyMemory. Instead `email` exists.