### PR TITLE
Deepl provider readme, pro and test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ Translate Tool in Python
 
 
 Translate is a simple but powerful translation tool written in python with with support for
-multiple translation providers. By now we offer integration with Microsoft Translation API and
-Translated MyMemory API
+multiple translation providers. By now we offer integration with Microsoft Translation API,
+Translated MyMemory API and DeepL's Free API
 
 
 Why Should I Use This?
@@ -138,7 +138,7 @@ Use a different translation provider
 
     In [1]: from translate import Translator
     In [2]: to_lang = 'zh'
-    In [3]: secret = '<your secret from Microsoft>'
+    In [3]: secret = '<your secret from Microsoft or DeepL>'
     In [4]: translator = Translator(provider='microsoft', to_lang=to_lang, secret_access_key=secret)
     In [5]: translator.translate('the book is on the table')
     Out [5]: '碗是在桌子上。'

--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,8 @@ The DeepL Provider
 To use DeepL's pro API, pass an additional parameter called pro to the Translator object and set it to True and use your pro authentication key as the secret_access_key
 
 .. code-block:: python
-    In [4]: translator = Translator(provider='microsoft', to_lang=to_lang, secret_access_key=secret, pro=True)
+
+    In: translator = Translator(provider='microsoft', to_lang=to_lang, secret_access_key=secret, pro=True)
 
 Documentation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -7,14 +7,14 @@ Translate Tool in Python
 
 Translate is a simple but powerful translation tool written in python with with support for
 multiple translation providers. By now we offer integration with Microsoft Translation API,
-Translated MyMemory API and DeepL's Free API
+Translated MyMemory API and DeepL's free and pro APIs
 
 
 Why Should I Use This?
 ----------------------
 
 The biggest reason to use translate is to  make translations in a simple way without the need of bigger
-effort and can be used as a translation tool like command line 
+effort and can be used as a translation tool like command line
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -139,10 +139,16 @@ Use a different translation provider
     In [1]: from translate import Translator
     In [2]: to_lang = 'zh'
     In [3]: secret = '<your secret from Microsoft or DeepL>'
-    In [4]: translator = Translator(provider='microsoft', to_lang=to_lang, secret_access_key=secret)
+    In [4]: translator = Translator(provider='<the name of the provider, eg. microsoft or deepl>', to_lang=to_lang, secret_access_key=secret)
     In [5]: translator.translate('the book is on the table')
     Out [5]: '碗是在桌子上。'
 
+The DeepL Provider
+~~~~~~~~~~~~~~~~~~
+To use DeepL's pro API, pass an additional parameter called pro to the Translator object and set it to True and use your pro authentication key as the secret_access_key
+
+.. code-block:: python
+    In [4]: translator = Translator(provider='microsoft', to_lang=to_lang, secret_access_key=secret, pro=True)
 
 Documentation
 -------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 from __future__ import unicode_literals
+import unittest
 try:
     from unittest import mock
 except Exception:
@@ -15,6 +16,12 @@ response_template = (
     '-------------------------\n'
     'Translated by: MyMemory\n'
 )
+deepl_response_template = (
+    '\nTranslation: {}\n'
+    '-------------------------\n'
+    'Translated by: Deepl\n'
+)
+deepl_secret = 'secret'
 
 
 @vcr.use_cassette
@@ -46,3 +53,9 @@ def test_main_from_language(cli_runner):
 def test_main_get_vesion(cli_runner):
     result = cli_runner.invoke(main, ['--version'])
     assert 'translate, version 0.0.0\n' == result.output
+
+
+@unittest.skipIf(deepl_secret == 'secret', 'No authentication token provided for DeepL')
+def test_main_deepl_provider(cli_runner):
+    result = cli_runner.invoke(main, ['--provider', 'deepl', '--from', 'de', '--to', 'zh', '--secret_access_key', deepl_secret, 'the book is on the table'])
+    assert deepl_response_template.format('书在桌上') == result.output

--- a/translate/main.py
+++ b/translate/main.py
@@ -133,8 +133,15 @@ def config_file(ctx, from_lang, to_lang, provider, secret_access_key):
     help="Set to display the translation only.",
     required=False,
 )
+@click.option(
+    'pro', '--pro',
+    default=False,
+    is_flag=True,
+    help="Set to use DeepL's pro API.",
+    required=False,
+)
 @click.argument('text', nargs=-1, type=click.STRING, required=True)
-def main(from_lang, to_lang, provider, secret_access_key, output_only, text):
+def main(from_lang, to_lang, provider, secret_access_key, output_only, pro, text):
     """
     Python command line tool to make on line translations
 
@@ -155,6 +162,7 @@ def main(from_lang, to_lang, provider, secret_access_key, output_only, text):
     kwargs = dict(from_lang=from_lang, to_lang=to_lang, provider=provider)
     if provider != DEFAULT_PROVIDER:
         kwargs['secret_access_key'] = secret_access_key
+        kwargs['pro'] = pro
 
     translator = Translator(**kwargs)
     translation = translator.translate(text)

--- a/translate/providers/base.py
+++ b/translate/providers/base.py
@@ -17,6 +17,7 @@ class BaseProvider:
         self.to_lang = to_lang
         self.secret_access_key = secret_access_key
         self.region = region
+        self.kwargs = kwargs
 
     @abstractmethod
     def get_translation(self, params):

--- a/translate/providers/deepl.py
+++ b/translate/providers/deepl.py
@@ -15,7 +15,16 @@ class DeeplProvider(BaseProvider):
     Documentation: https://www.deepl.com/docs-api
     '''
     name = 'Deepl'
-    base_url = 'https://api-free.deepl.com/v2/translate'
+    base_free_url = 'https://api-free.deepl.com/v2/translate'
+    base_pro_url = 'https://api.deepl.com/v2/translate'
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(**kwargs)
+        except TypeError:
+            super(DeeplProvider, self).__init__(**kwargs)
+        self.pro = self.kwargs.get('pro', False)
+        self.base_url = self.base_pro_url if self.pro else self.base_free_url
 
     def _make_request(self, text):
         params = {


### PR DESCRIPTION
Thanks for merging the pull request from earlier.
I've updated the readme and added the option to choose between DeepL's free and pro APIs.
I wasn't sure about the test since the secret_access_key is required. I've written a test in test_main.py which is skipped if the key isn't provided. 
If this is fine, I can write additional tests the same way to test the provider as well.