### PR TITLE
Removed hardcoded region for microsoft provider

### DIFF
--- a/translate/providers/microsoft.py
+++ b/translate/providers/microsoft.py
@@ -21,8 +21,7 @@ class MicrosoftProvider(BaseProvider):
 
     def _make_request(self, text):
         self.headers.update({"Ocp-Apim-Subscription-Key": self.secret_access_key})
-        if self.region is not None:
-            self.headers.update({"Ocp-Apim-Subscription-Region": "westeurope"})
+        self.headers.update({"Ocp-Apim-Subscription-Region": self.region or "westeurope"})
 
         params = {
                 'to': self.to_lang,


### PR DESCRIPTION
Removed the hardcoded region for the Microsoft Translate provider which caused errors for anybody not using westeurope. Previously, the region was not used.

region probably needs to be added to the docs, too.