### PR TITLE
docs: fix simple typo, infomations -> information

### DIFF
--- a/translate/providers/mymemory_translated.py
+++ b/translate/providers/mymemory_translated.py
@@ -14,7 +14,7 @@ class MyMemoryProvider(BaseProvider):
 
     Usage Tips: Use a valid email instead of the default.
         With a valid email you get 10 times more words/day to translate.
-    For further infomations checkout:
+    For further information checkout:
     http://mymemory.translated.net/doc/usagelimits.php
                                                     Tips from: @Bachstelze
     '''


### PR DESCRIPTION
There is a small typo in translate/providers/mymemory_translated.py.

Should read `information` rather than `infomations`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md